### PR TITLE
Rancher ci cd

### DIFF
--- a/.rancher-pipeline.yml
+++ b/.rancher-pipeline.yml
@@ -1,0 +1,12 @@
+stages:
+- name: Publish
+  steps:
+  - publishImageConfig:
+      dockerfilePath: ./Dockerfile
+      buildContext: .
+      tag: ct-diag-server:${CICD_EXECUTION_SEQUENCE}
+- name: Deploy
+  steps:
+  - applyYamlConfig:
+      path: ./deployment.yaml
+notification: {}

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -1,0 +1,36 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ct-diag-server-pipe
+spec:
+  selector:
+    app: ct-diag-server-pipe
+  type: NodePort
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ct-diag-server
+  labels:
+    app: ct-diag-server-pipe
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ct-diag-server-pipe
+  template:
+    metadata:
+      labels:
+        app: ct-diag-server-pipe
+    spec:
+      imagePullSecrets:
+      - name: pipeline-docker-registry
+      containers:
+      - name: ct-diag-server-pipe
+        image: ${CICD_IMAGE}:${CICD_EXECUTION_SEQUENCE}
+        ports:
+        - containerPort: 80


### PR DESCRIPTION
By adding these 2 files, it becomes easy for me to integrate CI/CD on a rancher kubernetes cluster. More info here: https://rancher.com/docker-based-build-pipelines-part-1-continuous-integration-and-testing/ since the files will not interfere with any other implementations, and hold no secrets, I guess there is no harm in the integration.