### PR TITLE
Return `200 OK` with `Content-Length: 0` on empty list

### DIFF
--- a/api/handler.go
+++ b/api/handler.go
@@ -43,7 +43,6 @@ func (h *handler) listDiagnosisKeys(w http.ResponseWriter, r *http.Request, _ ht
 	}
 
 	if len(diagKeys) == 0 {
-		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 


### PR DESCRIPTION
Returning a `204 No Content` status semantically isn't correct,
because there is content (a list of diagnosis keys), but it's empty.
Thus, return `200 OK` with `Content-Length: 0`.

**Note:** When not explicitly writing a header, Go uses `200 OK`. When no data is written in the HTTP response, it will set `Content-Length: 0` automatically. I'll assert these things in tests in a separate PR.

Ref: https://codefornl.slack.com/archives/C011R4NCFMJ/p1587639623194800?thread_ts=1587627915.169100&cid=C011R4NCFMJ

Fixes #3