### PR TITLE
Add initial tests for HTTP handlers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,5 @@
   "go.testEnvVars": {
     "POSTGRES_DSN": "postgres://ct-diag-test:ct-diag-test@127.0.0.1:54321/ct-diag-test?sslmode=disable"
   },
-  "go.testFlags": ["-v"]
+  "go.testFlags": ["-v", "-cover"]
 }

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Diagnosis Keys.
 
 ## TODO
 
-- [ ] Add tests for HTTP handlers.
 - [ ] Design and implement spec for creation of short lived OTPs for health care
       professionals, to be used as a bearer token for device users to authenticate
       the `POST` request for uploading Diagnosis Keys.

--- a/api/handler.go
+++ b/api/handler.go
@@ -43,6 +43,7 @@ func (h *handler) listDiagnosisKeys(w http.ResponseWriter, r *http.Request, _ ht
 	}
 
 	if len(diagKeys) == 0 {
+		w.Header().Set("Content-Length", "0")
 		return
 	}
 

--- a/api/handler.go
+++ b/api/handler.go
@@ -77,12 +77,12 @@ func (h *handler) postDiagnosisKeys(w http.ResponseWriter, r *http.Request, _ ht
 
 	for {
 		keyBuf := make([]byte, 16)
-		_, err := r.Body.Read(keyBuf)
+		_, err := io.ReadFull(r.Body, keyBuf)
 		if err == io.EOF {
 			break
 		}
 		if err != nil {
-			http.Error(w, "Invalid body", http.StatusBadRequest)
+			http.Error(w, fmt.Sprintf("Invalid diagnosis key: %v", err), http.StatusBadRequest)
 			return
 		}
 
@@ -92,22 +92,23 @@ func (h *handler) postDiagnosisKeys(w http.ResponseWriter, r *http.Request, _ ht
 			return
 		}
 
-		key, err := uuid.FromBytes(keyBuf)
-		if err != nil {
-			http.Error(w, fmt.Sprintf("Invalid UUID: %v", err), http.StatusBadRequest)
-			return
+		var key uuid.UUID
+		copy(key[:], keyBuf)
+
+		if version := key.Version(); version != 4 {
+			http.Error(w, fmt.Sprintf("Invalid UUID version: %s", version), http.StatusBadRequest)
+		}
+		if variant := key.Variant(); variant != uuid.RFC4122 {
+			http.Error(w, fmt.Sprintf("Invalid UUID variant: %s", variant), http.StatusBadRequest)
 		}
 
-		var dayNumber uint16
-		err = binary.Read(r.Body, binary.BigEndian, &dayNumber)
-		if err == io.EOF {
-			http.Error(w, "Missing day number", http.StatusBadRequest)
-			return
-		}
+		dayNumBuf := make([]byte, 2)
+		_, err = io.ReadFull(r.Body, dayNumBuf)
 		if err != nil {
-			http.Error(w, "Invalid day number", http.StatusBadRequest)
+			http.Error(w, fmt.Sprintf("Invalid day number: %v", err), http.StatusBadRequest)
 			return
 		}
+		dayNumber := binary.BigEndian.Uint16(dayNumBuf)
 
 		diagKeys = append(diagKeys, diag.DiagnosisKey{Key: key, DayNumber: dayNumber})
 	}
@@ -123,6 +124,8 @@ func (h *handler) postDiagnosisKeys(w http.ResponseWriter, r *http.Request, _ ht
 		writeInternalErrorResp(w, err)
 		return
 	}
+
+	fmt.Fprintf(w, "OK")
 }
 
 func writeInternalErrorResp(w http.ResponseWriter, err error) {

--- a/api/handler.go
+++ b/api/handler.go
@@ -27,7 +27,7 @@ func NewHandler(repo diag.Repository) http.Handler {
 	router.GET("/diagnosis-keys", h.listDiagnosisKeys)
 	router.POST("/diagnosis-keys", h.postDiagnosisKeys)
 	router.GET("/health", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-		w.Write([]byte("OK"))
+		fmt.Fprint(w, "OK")
 	})
 
 	return router
@@ -125,7 +125,7 @@ func (h *handler) postDiagnosisKeys(w http.ResponseWriter, r *http.Request, _ ht
 		return
 	}
 
-	fmt.Fprintf(w, "OK")
+	fmt.Fprint(w, "OK")
 }
 
 func writeInternalErrorResp(w http.ResponseWriter, err error) {

--- a/api/handler_test.go
+++ b/api/handler_test.go
@@ -1,0 +1,151 @@
+package api
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/dstotijn/ct-diag-server/diag"
+	"github.com/google/uuid"
+)
+
+type testRepository struct {
+	storeDiagnosisKeysFn   func(context.Context, []diag.DiagnosisKey) error
+	findAllDiagnosisKeysFn func(context.Context) ([]diag.DiagnosisKey, error)
+}
+
+func (ts testRepository) StoreDiagnosisKeys(ctx context.Context, diagKeys []diag.DiagnosisKey) error {
+	return ts.storeDiagnosisKeysFn(ctx, diagKeys)
+}
+
+func (ts testRepository) FindAllDiagnosisKeys(ctx context.Context) ([]diag.DiagnosisKey, error) {
+	return ts.findAllDiagnosisKeysFn(ctx)
+}
+
+func TestListDiagnosisKeys(t *testing.T) {
+	t.Run("no diagnosis keys found", func(t *testing.T) {
+		repo := testRepository{
+			findAllDiagnosisKeysFn: func(_ context.Context) ([]diag.DiagnosisKey, error) {
+				return nil, nil
+			},
+		}
+		handler := NewHandler(repo)
+		req := httptest.NewRequest("GET", "http://example.com/diagnosis-keys", nil)
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+		resp := w.Result()
+
+		expStatusCode := 200
+		if got := resp.StatusCode; got != expStatusCode {
+			t.Errorf("expected: %v, got: %v", expStatusCode, got)
+		}
+
+		expContentLength := "0"
+		if got := resp.Header.Get("Content-Length"); got != expContentLength {
+			t.Errorf("expected: %v, got: %v", expContentLength, got)
+		}
+	})
+
+	t.Run("diagnosis keys found", func(t *testing.T) {
+		expDiagKeys := []diag.DiagnosisKey{
+			{
+				Key:       uuid.MustParse("adc69f96-c83f-4c2b-8905-ddf2b6ba8543"),
+				DayNumber: uint16(42),
+			},
+		}
+		repo := testRepository{
+			findAllDiagnosisKeysFn: func(_ context.Context) ([]diag.DiagnosisKey, error) {
+				return expDiagKeys, nil
+			},
+		}
+
+		handler := NewHandler(repo)
+		req := httptest.NewRequest("GET", "http://example.com/diagnosis-keys", nil)
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+		resp := w.Result()
+
+		expStatusCode := 200
+		if got := resp.StatusCode; got != expStatusCode {
+			t.Errorf("expected: %v, got: %v", expStatusCode, got)
+		}
+
+		expContentLength := strconv.Itoa(len(expDiagKeys) * 18)
+		if got := resp.Header.Get("Content-Length"); got != expContentLength {
+			t.Fatalf("expected: %v, got: %v", expContentLength, got)
+		}
+
+		var got []diag.DiagnosisKey
+
+		for {
+			keyBuf := make([]byte, 16)
+			_, err := resp.Body.Read(keyBuf)
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				http.Error(w, "Invalid body", http.StatusBadRequest)
+				return
+			}
+
+			key, err := uuid.FromBytes(keyBuf)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var dayNumber uint16
+			err = binary.Read(resp.Body, binary.BigEndian, &dayNumber)
+			if err == io.EOF {
+				t.Fatal(err)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got = append(got, diag.DiagnosisKey{Key: key, DayNumber: dayNumber})
+		}
+
+		if !reflect.DeepEqual(got, expDiagKeys) {
+			t.Errorf("expected: %#v, got: %#v", expDiagKeys, got)
+		}
+	})
+
+	t.Run("diag.Service returns error", func(t *testing.T) {
+		repo := testRepository{
+			findAllDiagnosisKeysFn: func(_ context.Context) ([]diag.DiagnosisKey, error) {
+				return nil, errors.New("foobar")
+			},
+		}
+		handler := NewHandler(repo)
+		req := httptest.NewRequest("GET", "http://example.com/diagnosis-keys", nil)
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+		resp := w.Result()
+
+		expStatusCode := 500
+		if got := resp.StatusCode; got != expStatusCode {
+			t.Errorf("expected: %v, got: %v", expStatusCode, got)
+		}
+
+		expBody := "Internal Server Error"
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got := strings.TrimSpace(string(body)); got != expBody {
+			t.Errorf("expected: %v, got: `%s`", expBody, got)
+		}
+	})
+}

--- a/api/handler_test.go
+++ b/api/handler_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"io"
 	"io/ioutil"
-	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"strconv"
@@ -120,8 +119,7 @@ func TestListDiagnosisKeys(t *testing.T) {
 				break
 			}
 			if err != nil {
-				http.Error(w, "Invalid body", http.StatusBadRequest)
-				return
+				t.Fatal(err)
 			}
 
 			key, err := uuid.FromBytes(keyBuf)


### PR DESCRIPTION
Additionally, adds small validation checks for UUID parsing and simplifies request body reads via `io.ReadFull`.