### PR TITLE
Make run-tests.sh work on more linux distros

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -Eeuo pipefail
 
 NAME="pg-ct-diag-test"


### PR DESCRIPTION
Not all linux distros have `bash` in `/bin`. A cross-platform way to find bash is to use `env` instead to locate it

( I couldn't run the test script on NixOS)